### PR TITLE
Fix support for React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "babel-preset-react": "^6.5.0"
   },
   "peerDependencies": {
-    "react": ">= ^0.14.0"
+    "react": ">=0.14.0"
   }
 }


### PR DESCRIPTION
Hello,
there's a conflict in react version used in your package. Using it I get warning during npm install:
`npm WARN react-close-on-escape@1.0.2 requires a peer of react@>= ^0.14.0 but none was installed.`
I think '^' is picked instead of '>='. Removing '^' from version solves the problem.
