### PR TITLE
Update PropTypes Deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-close-on-escape",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "close react component on press escape",
   "main": "dist/index.js",
   "scripts": {
@@ -30,6 +30,7 @@
     "babel-preset-react": "^6.5.0"
   },
   "peerDependencies": {
-    "react": ">=0.14.0"
+    "prop-types": ">15.5.0",
+    "react": ">15.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-preset-react": "^6.5.0"
   },
   "peerDependencies": {
-    "prop-types": ">15.5.0",
-    "react": ">15.5.0"
+    "prop-types": ">=15.5.0",
+    "react": ">=15.5.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, Children } from 'react';
+import React, { Component, Children } from 'react';
+import PropTypes from 'prop-types';
 
 export default class CloseOnEscape extends Component {
   constructor() {


### PR DESCRIPTION
Howdy! PropTypes is being moved out of the core React package in the [next major release](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html), this patch updates the import.